### PR TITLE
add method GetIsATemplate() to vm

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -572,6 +572,15 @@ func (self *VM) SetIsATemplate(is_a_template bool) (err error) {
 	return
 }
 
+func (self *VM) GetIsATemplate() (is_a_template bool, err error) {
+	result := APIResult{}
+	err = self.Client.APICall(&result, "VM.get_is_a_template", self.Ref)
+	if err != nil {
+		return false, err
+	}
+	return result.Value.(bool), nil
+}
+
 func (self *VM) GetOtherConfig() (other_config map[string]string, err error) {
 	result := APIResult{}
 	other_config = make(map[string]string)


### PR DESCRIPTION
This method can be used to exclude templates from the result of
GetVMAll().

Signed-off-by: Talons Lee <xin.li@citrix.com>